### PR TITLE
WIP: Properly terminate Ngrok when NGROK:STOP is called

### DIFF
--- a/ngrok-tests.asd
+++ b/ngrok-tests.asd
@@ -1,0 +1,6 @@
+(defsystem "ngrok-tests"
+  :class :package-inferred-system
+  :pathname "tests"
+  :depends-on ("rove"
+               "ngrok-tests/setup")
+  :perform (test-op (o c) (symbol-call :rove '#:run c)))

--- a/ngrok.asd
+++ b/ngrok.asd
@@ -1,8 +1,9 @@
-(defsystem "ngrok" 
+(defsystem "ngrok"
   :class :package-inferred-system
   :author "Alexander Artemenko"
   :license "Unlicense"
   :pathname "src"
   :description "A wrapper around ngrok to help debug remote Lisp servers."
   :depends-on ("trivial-features"
-               "ngrok/setup"))
+               "ngrok/setup")
+  :in-order-to ((test-op (test-op "ngrok-tests"))))

--- a/src/setup.lisp
+++ b/src/setup.lisp
@@ -2,7 +2,8 @@
   (:use #:cl)
   (:nicknames #:ngrok/setup)
   (:import-from #:ngrok/utils
-                #:run)
+                #:run
+                #:terminate-running-command)
   (:import-from #:log4cl)
   (:import-from #:bordeaux-threads)
   (:import-from #:jonathan)
@@ -124,10 +125,8 @@
 
 
 (defun stop ()
-  ;; TODO: this function does not kill ngrok
-  ;; we need to find a good way to kill child process.
   (when *thread*
     (when (bt:thread-alive-p *thread*)
-      (bt:destroy-thread *thread*))
+      (bt:interrupt-thread *thread* #'terminate-running-command))
     (setf *thread* nil
           *port* nil)))

--- a/tests/setup.lisp
+++ b/tests/setup.lisp
@@ -1,0 +1,31 @@
+(defpackage #:ngrok-tests/setup
+  (:use #:cl
+        #:rove)
+  (:shadowing-import-from #:rove
+                          #:*debug-on-error*)
+  (:import-from #:ngrok)
+  (:import-from #:find-port))
+(in-package #:ngrok-tests/setup)
+
+(deftest start
+  (testing "happy-path"
+    (unwind-protect (multiple-value-bind (tunnel-url webserver-port)
+                        (ngrok:start (find-port:find-port))
+                      (ok tunnel-url "Returns Ngrok public URL")
+                      (ok webserver-port "Returns Ngrok webserver port number")
+
+                      (ng (find-port:port-open-p webserver-port)
+                          "Ngrok Web server listens to one port"))
+      (ngrok:stop))))
+
+(deftest stop
+  (testing "happy-path"
+    (let ((webserver-port (nth-value 1 (ngrok:start (find-port:find-port)))))
+      (when (find-port:port-open-p webserver-port)
+        (error "Ngrok expected to be running, but it's not"))
+
+      (ngrok:stop)
+      (sleep 0.1) ;; give some time for Ngrok to shut itself down
+
+      (ok (find-port:port-open-p webserver-port)
+          "Ngrok Web server is shut down"))))


### PR DESCRIPTION
UIOP:LAUNCH-PROGRAM is now used instead of UIP:RUN-PROGRAM; this enables
us to establish a restart which, when invoked, we can use to gracefully
terminate the running command (interrupting a call to UIOP:RUN-PROGRAM
unfortunately does not cause the underlying command to be terminated).

To actually terminate a running program, one has to invoke
TERMINATE-RUNNING-COMMAND in the same execution context the program we
want to terminate is running on.  This means that the only reasonable
use case for this, is if we had wrapped the RUN call inside
BT:MAKE-THREAD, and now we wanted to break into that running thread
with BT:INTERRUPT-THREAD.  Guess what, that's exactly what NGROK:STOP
is now doing, calling BT:INTERRUPT-THREAD with
TERMINATE-RUNNING-COMMAND.